### PR TITLE
fixed bug causing a phantom cell 256

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ function execute_opcode(op){
 			break;
 		case '>':
 			g_mp++;
-			if (g_mp > g_max_mem) g_mp = 0;
+			if (g_mp >= g_max_mem) g_mp = 0;
 			break;
 		case '<':
 			g_mp--;


### PR DESCRIPTION
~~this is my first time submitting a pull request, i'm probably doing something wrong~~

Back when `g_max_mem` was changed from being the number of the highest cell to being the number of cells ([this commit](https://github.com/iamcal/brainfuck-debug/commit/c1fb1284c3f654d8ec589783ff4bb8a0e70b7db4)), it broke the looping tape. Doing `<` from cell 0 brought the pointer to cell 255, as expected, but `>` from cell 255 put you in cell 256. The "does the tape wrap here" check wasn't updated. Using `>=` instead of `>` appears to do the trick. I tested it to the best of my ability but I'm not too good with javascript.

This change resolves both currently outstanding issues ([[1]](https://github.com/iamcal/brainfuck-debug/issues/6), [[2]](https://github.com/iamcal/brainfuck-debug/issues/4)).
